### PR TITLE
Add explicit .once method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### Edge
 
+ - Add `once` countable qualifier syntax sugar (#2, @inkstak)
 
 ### 1.2.0 - 2021-03-28
 

--- a/lib/rspec/enqueue_sidekiq_job.rb
+++ b/lib/rspec/enqueue_sidekiq_job.rb
@@ -66,6 +66,10 @@ module RSpec
         self
       end
 
+      def once
+        exactly(1).times
+      end
+
       def twice
         exactly(2).times
       end

--- a/spec/rspec/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/enqueue_sidekiq_job_spec.rb
@@ -102,6 +102,21 @@ RSpec.describe RSpec::EnqueueSidekiqJob do
         .and enqueue_sidekiq_job(another_worker)
     end
 
+    it 'passes when explicitly expected to be enqueued once' do
+      expect {
+        worker.perform_async
+      }.to enqueue_sidekiq_job(worker).once
+    end
+
+    it 'fails when explicitly expected to be enqueued once, but enqueued twice' do
+      expect {
+        expect {
+          worker.perform_async
+          worker.perform_async
+        }.to enqueue_sidekiq_job(worker).once
+      }.to raise_error(/expected to enqueue/)
+    end
+
     it 'passes when explicitly expected to be enqueued twice' do
       expect {
         worker.perform_async


### PR DESCRIPTION
**Note** : this PR is a duplicate of #1.
I've create this new PR to specify another branch from my fork. I'll then be able to create another PR from another branch later.

--


I know that :

> `enqueue_sidekiq_job` implies "exactly once" by default. But you can adjust that.

but I would prefer to add a explicit `.once` when writing specs : they are also meant to be read by other developers and not everyone may be familiar with the "it implies exactly once" convention.

