### PR TITLE
Allow to pass a block to

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,12 +7,19 @@ AllCops:
   NewCops: disable
   TargetRubyVersion: 2.4
 
-Metrics/BlockLength:
+Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*.rb
 
 Metrics/AbcSize:
   Max: 18
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+
+Metrics/ClassLength:
+  Max: 120
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/lib/rspec/enqueue_sidekiq_job.rb
+++ b/lib/rspec/enqueue_sidekiq_job.rb
@@ -50,7 +50,7 @@ module RSpec
 
       def with(*expected_arguments, &block)
         if block
-          raise ArgumentError, "setting arguments with block is not supported" if expected_arguments.any?
+          raise ArgumentError, 'setting arguments with block is not supported' if expected_arguments.any?
 
           @expected_arguments = block
         else
@@ -144,7 +144,7 @@ module RSpec
 
         if @expected_arguments.is_a?(Proc)
           arguments = @expected_arguments.call(result)
-          raise "`with` block is expected to return an Array" unless arguments.is_a?(Array)
+          raise '`with` block is expected to return an Array' unless arguments.is_a?(Array)
 
           @expected_arguments = normalize_arguments(arguments)
         end

--- a/spec/rspec/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/enqueue_sidekiq_job_spec.rb
@@ -279,14 +279,14 @@ RSpec.describe RSpec::EnqueueSidekiqJob do
     it 'passes with provided arguments' do
       expect {
         worker.perform_async(42, 'David')
-        "David"
+        'David'
       }.to enqueue_sidekiq_job(worker).with { |name| [42, name] }
     end
 
     it 'passes when negated and arguments do not match' do
-      expect expect {
+      expect {
         worker.perform_async(42, 'David')
-        "Phil"
+        'Phil'
       }.not_to enqueue_sidekiq_job(worker).with { |name| [42, name] }
     end
 
@@ -294,7 +294,7 @@ RSpec.describe RSpec::EnqueueSidekiqJob do
       expect {
         expect {
           worker.perform_async(42, 'David')
-          "Phil"
+          'Phil'
         }.to enqueue_sidekiq_job(worker).with { |name| [42, name] }
       }.to raise_error(/expected to enqueue.+arguments:/m)
     end
@@ -303,16 +303,16 @@ RSpec.describe RSpec::EnqueueSidekiqJob do
       expect {
         expect { worker.perform_async(42, 'David') }
           .to enqueue_sidekiq_job(worker).with(42) { |name| [42, name] }
-      }.to raise_error(ArgumentError, "setting arguments with block is not supported")
+      }.to raise_error(ArgumentError, 'setting arguments with block is not supported')
     end
 
     it 'rejects arguments returned from block if they are not an Array' do
       expect {
         expect {
           worker.perform_async(42, 'David')
-          "Phil"
+          'Phil'
         }.to enqueue_sidekiq_job(worker).with { |name| name }
-      }.to raise_error("`with` block is expected to return an Array")
+      }.to raise_error('`with` block is expected to return an Array')
     end
   end
 end

--- a/spec/rspec/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/enqueue_sidekiq_job_spec.rb
@@ -278,40 +278,40 @@ RSpec.describe RSpec::EnqueueSidekiqJob do
   context 'with block arguments' do
     it 'passes with provided arguments' do
       expect {
-        worker.perform_async(42, 'David')
+        Worker.perform_async(42, 'David')
         'David'
-      }.to enqueue_sidekiq_job(worker).with { |name| [42, name] }
+      }.to enqueue_sidekiq_job(Worker).with { |name| [42, name] }
     end
 
     it 'passes when negated and arguments do not match' do
       expect {
-        worker.perform_async(42, 'David')
+        Worker.perform_async(42, 'David')
         'Phil'
-      }.not_to enqueue_sidekiq_job(worker).with { |name| [42, name] }
+      }.not_to enqueue_sidekiq_job(Worker).with { |name| [42, name] }
     end
 
     it 'fails when arguments do not match' do
       expect {
         expect {
-          worker.perform_async(42, 'David')
+          Worker.perform_async(42, 'David')
           'Phil'
-        }.to enqueue_sidekiq_job(worker).with { |name| [42, name] }
+        }.to enqueue_sidekiq_job(Worker).with { |name| [42, name] }
       }.to raise_error(/expected to enqueue.+arguments:/m)
     end
 
     it 'rejects arguments mixed with block' do
       expect {
-        expect { worker.perform_async(42, 'David') }
-          .to enqueue_sidekiq_job(worker).with(42) { |name| [42, name] }
+        expect { Worker.perform_async(42, 'David') }
+          .to enqueue_sidekiq_job(Worker).with(42) { |name| [42, name] }
       }.to raise_error(ArgumentError, 'setting arguments with block is not supported')
     end
 
     it 'rejects arguments returned from block if they are not an Array' do
       expect {
         expect {
-          worker.perform_async(42, 'David')
+          Worker.perform_async(42, 'David')
           'Phil'
-        }.to enqueue_sidekiq_job(worker).with { |name| name }
+        }.to enqueue_sidekiq_job(Worker).with { |name| name }
       }.to raise_error('`with` block is expected to return an Array')
     end
   end


### PR DESCRIPTION
This third PR allows to pass a block to `with`.
The result of the `expect {}` block is passed to the `with {}` block and the returned value is used to match arguments.

This is useful to match arguments against something created in the `expect {}` block:

```ruby
it do
  expect { create(:user) }
    .to enqueue_sidekiq_job(AwesomeWorker).with { |user| [user.email] }
end
```