### PR TITLE
Add description to matcher

### DIFF
--- a/lib/rspec/enqueue_sidekiq_job.rb
+++ b/lib/rspec/enqueue_sidekiq_job.rb
@@ -80,6 +80,20 @@ module RSpec
         filter(enqueued_in_block(block)).none?
       end
 
+      def description
+        description = "enqueue #{worker_class} job"
+        description +=
+          if !expected_count || expected_count == 1
+            " once"
+          elsif expected_count == 2
+            " twice"
+          else
+            " #{expected_count} times"
+          end
+
+        description
+      end
+
       def failure_message
         message = ["expected to enqueue #{worker_class} job"]
         message << "  arguments: #{expected_arguments}" if expected_arguments


### PR DESCRIPTION
When using the matcher in an example without description, Rspec outputs long warnings for each test:

```ruby 
it { is_expected.to enqueue_sidekiq_job(RandomWorker) }
```
```
$ rspec -f doc ./spec/my_class_spec.rb:9

MyClass
  is expected to When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.

Top 1 slowest examples (0.00738 seconds, 88.9% of total time):
  MyClass is expected to When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.
    0.00738 seconds ./spec/my_class_spec.rb:9
```

Adding a description to the matcher now outputs:

```
$ rspec -f doc ./spec/my_class_spec.rb:9

MyClass
  is expected to enqueue RandomWorker job once

Top 1 slowest examples (0.00777 seconds, 90.6% of total time):
  MyClass is expected to enqueue SomeJob job once
    0.00777 seconds ./spec/my_class_spec.rb:9

Finished in 0.00857 seconds (files took 2.26 seconds to load)
1 example, 0 failures